### PR TITLE
added custom primary color to tailwind

### DIFF
--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -1,3 +1,9 @@
+:root {
+  --color-primary-light: #ded3ff;
+  --color-primary: #5f2eea;
+  --color-primary-dark: #2a00a2;
+}
+
 @tailwind base;
 @tailwind components;
 @tailwind utilities;

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -2,7 +2,17 @@ module.exports = {
   purge: ["./src/**/*.{js,jsx,ts,tsx}", "./public/index.html"],
   darkMode: false, // or 'media' or 'class'
   theme: {
-    extend: {},
+    extend: {
+      colors: {
+        transparent: "transparent",
+        current: "currentColor",
+        primary: {
+          light: "var(--color-primary--light)",
+          DEFAULT: "var(--color-primary)",
+          dark: "var(--color-primary--dark)",
+        },
+      },
+    },
   },
   variants: {
     extend: {},


### PR DESCRIPTION
The following colors can now be used wherever you would use a tailwind color name:
- primary
- primary-light
- primary-dark